### PR TITLE
Fix service name

### DIFF
--- a/DependencyInjection/AccordMandrillSwiftMailerExtension.php
+++ b/DependencyInjection/AccordMandrillSwiftMailerExtension.php
@@ -25,9 +25,9 @@ class AccordMandrillSwiftMailerExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 		
-		$crudRegistryServiceDefinition = $container->getDefinition('swiftmailer.mailer.transport.mandrill');
+		$crudRegistryServiceDefinition = $container->getDefinition('swiftmailer.mailer.transport.accord_mandrill');
         $crudRegistryServiceDefinition->addMethodCall('setApiKey', array( $config['api_key'] ));
         
-		$container->setAlias('accord_mandrill', 'swiftmailer.mailer.transport.mandrill');
+		$container->setAlias('accord_mandrill', 'swiftmailer.mailer.transport.accord_mandrill');
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,7 +4,7 @@ services:
     swiftmailer.transport.eventdispatcher.accord_mandrill: 
         class: Swift_Events_SimpleEventDispatcher
     
-    swiftmailer.mailer.transport.mandrill:
+    swiftmailer.mailer.transport.accord_mandrill:
         class: Accord\MandrillSwiftMailerBundle\SwiftMailer\MandrillTransport
         arguments:
             - @swiftmailer.transport.eventdispatcher.accord_mandrill


### PR DESCRIPTION
I couldn't make this bundle work out of the box as swiftmailer bundle forces the name of the transport:
```
 foreach ($mailers as $name => $mailer) {
    $plugins = $container->findTaggedServiceIds(sprintf('swiftmailer.%s.plugin', $name));
    $transport = sprintf('swiftmailer.mailer.%s.transport', $name);
    $definition = $container->findDefinition($transport);
    foreach ($plugins as $id => $args) {
        $definition->addMethodCall('registerPlugin', array(new Reference($id)));
    }
}
```
so it was looking for a service named ``swiftmailer.mailer.transport.accord_mandrill``.
This PR solves the issue.