### PR TITLE
Fix service name

### DIFF
--- a/DependencyInjection/AccordMandrillSwiftMailerExtension.php
+++ b/DependencyInjection/AccordMandrillSwiftMailerExtension.php
@@ -25,9 +25,9 @@ class AccordMandrillSwiftMailerExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 		
-		$crudRegistryServiceDefinition = $container->getDefinition('swiftmailer.mailer.transport.mandrill');
+		$crudRegistryServiceDefinition = $container->getDefinition('swiftmailer.mailer.transport.accord_mandrill');
         $crudRegistryServiceDefinition->addMethodCall('setApiKey', array( $config['api_key'] ));
         
-		$container->setAlias('accord_mandrill', 'swiftmailer.mailer.transport.mandrill');
+		$container->setAlias('accord_mandrill', 'swiftmailer.mailer.transport.accord_mandrill');
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,7 +4,7 @@ services:
     swiftmailer.transport.eventdispatcher.accord_mandrill: 
         class: Swift_Events_SimpleEventDispatcher
     
-    swiftmailer.mailer.transport.mandrill:
+    swiftmailer.mailer.transport.accord_mandrill:
         class: Accord\MandrillSwiftMailerBundle\SwiftMailer\MandrillTransport
         arguments:
             - @swiftmailer.transport.eventdispatcher.accord_mandrill


### PR DESCRIPTION
I couldn't make this bundle work out of the box due to Symfony swift mailer bundle that has this in it's extension class:
```
 $container->setAlias(sprintf('swiftmailer.mailer.%s.transport', $name), sprintf('swiftmailer.mailer.transport.%s', $transport));
```
So this PR fixes the naming issue.